### PR TITLE
 增加 UnitTest 支持

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,13 @@
       "src/Helper/Functions.php"
     ]
   },
+  "autoload-dev": {
+    "classmap": [
+    ],
+    "psr-4": {
+      "Swoft\\Test\\": "test/"
+    }
+  },
   "repositories": {
     "packagist": {
       "type": "composer",
@@ -29,6 +36,7 @@
     }
   },
   "require-dev": {
-    "eaglewu/swoole-ide-helper": "dev-master"
+    "eaglewu/swoole-ide-helper": "dev-master",
+    "phpunit/phpunit": "^5.7"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,6 @@
     ]
   },
   "autoload-dev": {
-    "classmap": [
-    ],
     "psr-4": {
       "Swoft\\Test\\": "test/"
     }

--- a/test/AbstractTestCase.php
+++ b/test/AbstractTestCase.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Swoft\Test;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @uses      AbstractTestCase
+ * @version   2017年11月03日
+ * @author    huangzhhui <huangzhwork@gmail.com>
+ * @copyright Copyright 2010-2016 Swoft software
+ * @license   PHP Version 7.x {@link http://www.php.net/license/3_0.txt}
+ */
+class AbstractTestCase extends TestCase
+{
+
+}

--- a/test/AbstractTestCase.php
+++ b/test/AbstractTestCase.php
@@ -8,7 +8,7 @@ use PHPUnit\Framework\TestCase;
  * @uses      AbstractTestCase
  * @version   2017年11月03日
  * @author    huangzhhui <huangzhwork@gmail.com>
- * @copyright Copyright 2010-2016 Swoft software
+ * @copyright Copyright 2010-2017 Swoft software
  * @license   PHP Version 7.x {@link http://www.php.net/license/3_0.txt}
  */
 class AbstractTestCase extends TestCase

--- a/test/Base/ConfigTest.php
+++ b/test/Base/ConfigTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Swoft\Test\Base;
+
+
+use Swoft\App;
+use Swoft\Base\Config;
+use Swoft\Test\AbstractTestCase;
+
+/**
+ * @uses      ConfigTest
+ * @version   2017年11月03日
+ * @author    huangzhhui <huangzhwork@gmail.com>
+ * @copyright Copyright 2010-2016 Swoft software
+ * @license   PHP Version 7.x {@link http://www.php.net/license/3_0.txt}
+ */
+class ConfigTest extends AbstractTestCase
+{
+
+    public function testConfig()
+    {
+        /** @var \Swoft\Base\Config $config */
+        $config = App::getBean('config');
+        $this->assertInstanceOf(Config::class, $config);
+        $value = 1;
+        $offset = 'test';
+        $this->assertFalse($config->offsetExists($offset));
+        $config->offsetSet($offset, $value);
+        $this->assertEquals($value, $config->current());
+        $this->assertEquals($value, $config->offsetGet($offset));
+        $this->assertTrue($config->offsetExists($offset));
+    }
+}

--- a/test/Base/ConfigTest.php
+++ b/test/Base/ConfigTest.php
@@ -11,7 +11,7 @@ use Swoft\Test\AbstractTestCase;
  * @uses      ConfigTest
  * @version   2017年11月03日
  * @author    huangzhhui <huangzhwork@gmail.com>
- * @copyright Copyright 2010-2016 Swoft software
+ * @copyright Copyright 2010-2017 Swoft software
  * @license   PHP Version 7.x {@link http://www.php.net/license/3_0.txt}
  */
 class ConfigTest extends AbstractTestCase

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,8 @@
+FROM swoft/swoft:latest
+
+MAINTAINER huangzhhui <huangzhwork@gmail.com>
+
+WORKDIR /var/www/swoft
+RUN composer install \
+    && composer dump-autoload -o \
+    && composer clearcache

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,9 @@
+# Automated Testing
+
+## Unit test
+
+### Start
+Docker Compose: `docker-compose up`
+
+## Standard of Script
+1. All `TestCase` should be extends `\Swoft\Test\AbstractTestCase` class

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,0 +1,9 @@
+<?php
+require_once dirname(dirname(__FILE__)) . "/vendor/autoload.php";
+require_once dirname(dirname(__FILE__)) . '/config/define.php';
+
+// init
+$server = new \Swoft\Server\HttpServer();
+\Swoft\Bean\BeanFactory::reload();
+$initApplicationContext = new \Swoft\Base\InitApplicationContext();
+$initApplicationContext->init();

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2'
+services:
+    swoft-unittest:
+        build: ./
+        container_name: swoft-unittest
+        volumes:
+            - ../:/var/www/swoft
+        working_dir: /var/www/swoft/test
+        command: ../vendor/bin/phpunit --bootstrap ./bootstrap.php --verbose ./


### PR DESCRIPTION
为框架增加 UnitTest 支持，使用 PHPUnit
通过 Docker 启动方法，需要安装 Docker Compose：
1. `cd test`
2. `docker-compose up`
