### PR TITLE
Always use dev version to run the tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ install:
   - wget https://github.com/redis/hiredis/archive/v0.13.3.tar.gz -O hiredis.tar.gz && mkdir -p hiredis && tar -xf hiredis.tar.gz -C hiredis --strip-components=1 && cd hiredis && sudo make -j$(nproc) && sudo make install && sudo ldconfig && cd ..
   - printf "\n" | pecl install -f swoole-2.1.3
 before_script:
+  - mv -f dev.composer.json composer.json
   - composer update --dev
 
 script: composer test


### PR DESCRIPTION
You should use dev version component to run all of the tests to make sure that it will work instead of waiting for stable packages update.