### PR TITLE
fix: cannot override Dockerfile startup command

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,4 @@ services:
        stdin_open: true 
        tty: true
        privileged: true
-       command: php /var/www/swoft/bin/swoft start
+       entrypoint: ["php", "/var/www/swoft/bin/swoft", "start"]


### PR DESCRIPTION
fix: https://github.com/swoft-cloud/swoft/issues/361