### PR TITLE
验证规则修复

### DIFF
--- a/app/Validator/Rule/AlphaDashRule.php
+++ b/app/Validator/Rule/AlphaDashRule.php
@@ -33,7 +33,7 @@ class AlphaDashRule implements RuleInterface
 
         $rule = '/^[A-Za-z0-9\-\_]+$/';
         if (preg_match($rule, $data[$propertyName])) {
-            return [$data];
+            return $data;
         }
 
         $message = (empty($message)) ? sprintf('%s must be a email', $propertyName) : $message;


### PR DESCRIPTION
修复使用验证规则 (\App\Validator\Rule\AlphaDashRule) 会导致Request获取数据出错的问题