### PR TITLE
Fix: validation rules (\App\Validator\Rule\AlphaDashRule)

### DIFF
--- a/app/Validator/Rule/AlphaDashRule.php
+++ b/app/Validator/Rule/AlphaDashRule.php
@@ -33,7 +33,7 @@ class AlphaDashRule implements RuleInterface
 
         $rule = '/^[A-Za-z0-9\-\_]+$/';
         if (preg_match($rule, $data[$propertyName])) {
-            return [$data];
+            return $data;
         }
 
         $message = (empty($message)) ? sprintf('%s must be a email', $propertyName) : $message;


### PR DESCRIPTION
Fixing the use of validation rules (\App\Validator\Rule\AlphaDashRule) will cause the Request to get data error