### PR TITLE
[Example] Resolving SessionInterface implementation differences

### DIFF
--- a/app/WebSocket/EchoModule.php
+++ b/app/WebSocket/EchoModule.php
@@ -33,7 +33,9 @@ class EchoModule
      */
     public function onOpen(Request $request, int $fd): void
     {
-        Session::mustGet()->push("Opened, welcome #{$fd}!");
+        /** @var \Swoft\WebSocket\Server\Connection */
+        $connection = Session::mustGet();
+        $connection->push("Opened, welcome #{$fd}!");
     }
 
     /**


### PR DESCRIPTION
Just like in https://github.com/swoft-cloud/swoft/blob/master/app/WebSocket/Test/TestController.php#L48-L52 because push is available only in `Swoft\WebSocket\Server\Connection`

@inhere Please close this PR without merging.